### PR TITLE
wip:virts-487

### DIFF
--- a/app/mock_svc.py
+++ b/app/mock_svc.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import re
 from random import randint
 
 
@@ -27,9 +28,11 @@ class MockService:
     async def load_simulation_results(self, simulated_responses):
         for simulated in simulated_responses:
             for p in simulated['paws']:
-                response = dict(ability_id=simulated['ability_id'], paw=p['paw'], status=p['status'],
-                                response=self.agent_svc.encode_string(p['response']))
-                await self.data_svc.create('sim_response', response)
+                for var in simulated[p]['var']:
+                    for val in simulated[p][var]:
+                        response = dict(ability_id=simulated['ability_id'], paw=p['paw'], status=p[var][val]['status'],
+                                    response=self.agent_svc.encode_string(p[var][val]['response']), var=var, val=val)
+                        await self.data_svc.create('sim_response', response)
 
     async def start_agent(self, agent):
         agent['pid'], agent['ppid'], agent['sleep'] = randint(1000, 10000), randint(1000, 10000), randint(55, 65)
@@ -40,19 +43,49 @@ class MockService:
 
     """ PRIVATE """
 
+    async def _extract_vars(self, ability):
+        decoded_test = self.agent_svc.decode_bytes(ability['command'])
+        variables = re.findall(r'#{(.*?)}', decoded_test, flags=re.DOTALL)
+        vars = [x for x in variables if x not in ['server','paw','location','group']]
+        search_set = []
+        filtering = decoded_test
+        for v in vars:
+            search_key, filtering = filtering.split("#{" + v + "}", 1)
+            search_set.append([v, search_key, filtering[0:3]])
+        return search_set
+
+    async def _extract_featured(self, vars, link):
+        decoded_command = self.agent_svc.decode_bytes(link['command'])
+        extracted = []
+        for v in vars:
+            extracted.append([v[0], re.findall(r'' + v[1] + '(.*)' +v[2], decoded_command, flags=re.DOTALL)[0]])
+        return extracted
+
+    async def _target_response(self, vars, response_object):
+        computable = dict()
+        for entry in response_object:
+            computable[entry['var']] = {entry['val']: entry['response']}
+        for v in vars:
+            if v[0] in computable:
+                if v[1] in computable[v[0]]:
+                    return computable[v[0]][v[1]]
+        return computable['default']['default']
+
     async def _get_simulated_response(self, link_id, paw):
         link = (await self.data_svc.get('core_chain', dict(id=link_id)))[0]
         if link['cleanup']:
             return '', 0
         ability = (await self.data_svc.get('core_ability', dict(id=link['ability'])))[0]
+        vars = await self._extract_vars(ability)
         sim_response = await self.data_svc.get('sim_response', dict(ability_id=ability['ability_id'], paw=paw))
         if not sim_response:
             return '', 0
-        if '|SPAWN|' in self.agent_svc.decode_bytes(sim_response[0]['response']):
+        targeted_response = await self._target_response(vars, sim_response)
+        if '|SPAWN|' in self.agent_svc.decode_bytes(targeted_response):
             if await self._spawn_new_sim(link):
-                return self.agent_svc.encode_string('spawned new agent'), sim_response[0]['status']
+                return self.agent_svc.encode_string('spawned new agent'), targeted_response[0]['status']
             return self.agent_svc.encode_string('failed to spawn new agent'), 1
-        return sim_response[0]['response'], sim_response[0]['status']
+        return targeted_response[0]['response'], targeted_response[0]['status']
 
     async def _spawn_new_sim(self, link):
         filtered = [a for a in self.agents if not a['enabled']]

--- a/conf/responses.yml
+++ b/conf/responses.yml
@@ -4,38 +4,44 @@
 - ability_id: c0da588f-79f0-4263-8998-7496b1a40596
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               darthvader
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               redleader
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               hansolo
     - paw: enterprise$picard
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               picard
     - paw: voyager$janeway
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               janeway
     - paw: defiant$sisko
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               sisko
@@ -44,38 +50,44 @@
 - ability_id: 6469befa-748a-4b9c-a96d-f191fde47d89
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\Users\Public\staging
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /Users/redleader/Desktop/staging
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /tmp/staging
     - paw: enterprise$picard
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\Users\Public\staging
     - paw: voyager$janeway
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /Users/redleader/Desktop/staging
     - paw: defiant$sisko
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /tmp/staging
@@ -84,44 +96,50 @@
 - ability_id: 90c2efaa-8205-480d-8bb6-61d90dbaf81b
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\sample.txt
               C:\Public\sample.yml
               C:\Windows\System32\configuration.yml
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /usr/local/bin/ansible/ansible.yml
               /Users/redleader/git.txt
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /mnt/shared.txt
     - paw: enterprise$picard
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\sample.txt
               C:\Public\sample.yml
               C:\Windows\System32\configuration.yml
     - paw: voyager$janeway
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /usr/local/bin/ansible/ansible.yml
               /Users/janeway/git.txt
     - paw: defiant$sisko
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /mnt/shared.txt
@@ -130,38 +148,44 @@
 - ability_id: 300157e5-f4ad-4569-b533-9d1fa0e74d74
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\Users\Public\staging.zip
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /Users/redleader/Desktop/staging.tar.gz
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /tmp/staging.tar.gz
     - paw: enterprise$picard
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               C:\Users\Public\staging.zip
     - paw: voyager$janeway
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /Users/janeway/Desktop/staging.tar.gz
     - paw: defiant$sisko
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               /tmp/staging.tar.gz
@@ -170,14 +194,16 @@
 - ability_id: 422526ec-27e9-429a-995b-c686a29561a4
   paws:
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               ssh janeway@voyager
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               ssh sisko@defiant
@@ -186,14 +212,16 @@
 - ability_id: c1cd6388-3ced-48c7-a511-0434c6ba8f48
   paws:
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               redleader
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               hansolo
@@ -202,14 +230,16 @@
 - ability_id: 02de522f-7e0a-4544-8afc-0c195f400f5f
   paws:
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               ssh janeway@voyager
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               ssh sisko@defiant
@@ -218,20 +248,23 @@
 - ability_id: 85341c8c-4ecb-4579-8f53-43e3e91d7617
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               128.127.126.125
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               111.111.111.110
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               3.141.59.26
@@ -240,8 +273,9 @@
 - ability_id: fa4ed735-7006-4451-a578-b516f80e559f
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               Name: enterprise
@@ -250,8 +284,9 @@
 - ability_id: fdf8bf36-797f-4157-805b-fe7c1c6fc903
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               enterprise <00> UNIQUE
@@ -260,8 +295,9 @@
 - ability_id: baac2c6d-4652-4b7e-ab0a-f1bf246edd12
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
                "* Username : picard
@@ -272,8 +308,9 @@
 - ability_id: 2a32e46f-5346-45d3-9475-52b857c05342
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               |SPAWN|
@@ -282,14 +319,16 @@
 - ability_id: 10a9d979-e342-418a-a9b0-002c483e0fa6
   paws:
     - paw: xwing$redleader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               |SPAWN|
     - paw: millenniumfalcon$hansolo
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               |SPAWN|
@@ -298,8 +337,9 @@
 - ability_id: 41bb2b7a-75af-49fd-bd15-6c827df25921
   paws:
     - paw: deathstar$darthvader
-      - var: default
-          - default:
+      details:
+        - default: #var
+          - value: default
             status: 0
             response: |
               |SPAWN|

--- a/conf/responses.yml
+++ b/conf/responses.yml
@@ -4,222 +4,302 @@
 - ability_id: c0da588f-79f0-4263-8998-7496b1a40596
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        darthvader
+      - var: default
+          - default:
+            status: 0
+            response: |
+              darthvader
     - paw: xwing$redleader
-      status: 0
-      response: |
-        redleader
+      - var: default
+          - default:
+            status: 0
+            response: |
+              redleader
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        hansolo
+      - var: default
+          - default:
+            status: 0
+            response: |
+              hansolo
     - paw: enterprise$picard
-      status: 0
-      response: |
-        picard
+      - var: default
+          - default:
+            status: 0
+            response: |
+              picard
     - paw: voyager$janeway
-      status: 0
-      response: |
-        janeway
+      - var: default
+          - default:
+            status: 0
+            response: |
+              janeway
     - paw: defiant$sisko
-      status: 0
-      response: |
-        sisko
+      - var: default
+          - default:
+            status: 0
+            response: |
+              sisko
 
 #create staging directory
 - ability_id: 6469befa-748a-4b9c-a96d-f191fde47d89
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        C:\Users\Public\staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\Users\Public\staging
     - paw: xwing$redleader
-      status: 0
-      response: |
-        /Users/redleader/Desktop/staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /Users/redleader/Desktop/staging
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        /tmp/staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /tmp/staging
     - paw: enterprise$picard
-      status: 0
-      response: |
-        C:\Users\Public\staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\Users\Public\staging
     - paw: voyager$janeway
-      status: 0
-      response: |
-        /Users/redleader/Desktop/staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /Users/redleader/Desktop/staging
     - paw: defiant$sisko
-      status: 0
-      response: |
-        /tmp/staging
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /tmp/staging
 
 #find sensitive files
 - ability_id: 90c2efaa-8205-480d-8bb6-61d90dbaf81b
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        C:\sample.txt
-        C:\Public\sample.yml
-        C:\Windows\System32\configuration.yml
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\sample.txt
+              C:\Public\sample.yml
+              C:\Windows\System32\configuration.yml
     - paw: xwing$redleader
-      status: 0
-      response: |
-        /usr/local/bin/ansible/ansible.yml
-        /Users/redleader/git.txt
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /usr/local/bin/ansible/ansible.yml
+              /Users/redleader/git.txt
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        /mnt/shared.txt
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /mnt/shared.txt
     - paw: enterprise$picard
-      status: 0
-      response: |
-        C:\sample.txt
-        C:\Public\sample.yml
-        C:\Windows\System32\configuration.yml
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\sample.txt
+              C:\Public\sample.yml
+              C:\Windows\System32\configuration.yml
     - paw: voyager$janeway
-      status: 0
-      response: |
-        /usr/local/bin/ansible/ansible.yml
-        /Users/janeway/git.txt
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /usr/local/bin/ansible/ansible.yml
+              /Users/janeway/git.txt
     - paw: defiant$sisko
-      status: 0
-      response: |
-        /mnt/shared.txt
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /mnt/shared.txt
 
 #compress staging directory
 - ability_id: 300157e5-f4ad-4569-b533-9d1fa0e74d74
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        C:\Users\Public\staging.zip
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\Users\Public\staging.zip
     - paw: xwing$redleader
-      status: 0
-      response: |
-        /Users/redleader/Desktop/staging.tar.gz
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /Users/redleader/Desktop/staging.tar.gz
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        /tmp/staging.tar.gz
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /tmp/staging.tar.gz
     - paw: enterprise$picard
-      status: 0
-      response: |
-        C:\Users\Public\staging.zip
+      - var: default
+          - default:
+            status: 0
+            response: |
+              C:\Users\Public\staging.zip
     - paw: voyager$janeway
-      status: 0
-      response: |
-        /Users/janeway/Desktop/staging.tar.gz
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /Users/janeway/Desktop/staging.tar.gz
     - paw: defiant$sisko
-      status: 0
-      response: |
-        /tmp/staging.tar.gz
+      - var: default
+          - default:
+            status: 0
+            response: |
+              /tmp/staging.tar.gz
 
 #dump history
 - ability_id: 422526ec-27e9-429a-995b-c686a29561a4
   paws:
     - paw: xwing$redleader
-      status: 0
-      response: |
-        ssh janeway@voyager
+      - var: default
+          - default:
+            status: 0
+            response: |
+              ssh janeway@voyager
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        ssh sisko@defiant
+      - var: default
+          - default:
+            status: 0
+            response: |
+              ssh sisko@defiant
 
 # Find local users
 - ability_id: c1cd6388-3ced-48c7-a511-0434c6ba8f48
   paws:
     - paw: xwing$redleader
-      status: 0
-      response: |
-        redleader
+      - var: default
+          - default:
+            status: 0
+            response: |
+              redleader
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        hansolo
+      - var: default
+          - default:
+            status: 0
+            response: |
+              hansolo
 
 # Parse SSH config
 - ability_id: 02de522f-7e0a-4544-8afc-0c195f400f5f
   paws:
     - paw: xwing$redleader
-      status: 0
-      response: |
-        ssh janeway@voyager
+      - var: default
+          - default:
+            status: 0
+            response: |
+              ssh janeway@voyager
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        ssh sisko@defiant
+      - var: default
+          - default:
+            status: 0
+            response: |
+              ssh sisko@defiant
 
 # Collect ARP details
 - ability_id: 85341c8c-4ecb-4579-8f53-43e3e91d7617
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        128.127.126.125
+      - var: default
+          - default:
+            status: 0
+            response: |
+              128.127.126.125
     - paw: xwing$redleader
-      status: 0
-      response: |
-        111.111.111.110
+      - var: default
+          - default:
+            status: 0
+            response: |
+              111.111.111.110
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        3.141.59.26
+      - var: default
+          - default:
+            status: 0
+            response: |
+              3.141.59.26
 
 # Reverse nslookup IP
 - ability_id: fa4ed735-7006-4451-a578-b516f80e559f
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        Name: enterprise
+      - var: default
+          - default:
+            status: 0
+            response: |
+              Name: enterprise
 
 # Find Hostname
 - ability_id: fdf8bf36-797f-4157-805b-fe7c1c6fc903
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-       enterprise <00> UNIQUE
+      - var: default
+          - default:
+            status: 0
+            response: |
+              enterprise <00> UNIQUE
 
 # Run PowerKatz
 - ability_id: baac2c6d-4652-4b7e-ab0a-f1bf246edd12
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-       "* Username : picard
-        * Domain   : sim/sim
-        * Password : MakeItSo"
+      - var: default
+          - default:
+            status: 0
+            response: |
+               "* Username : picard
+                * Domain   : sim/sim
+                * Password : MakeItSo"
 
 # Start 54ndc47 (WMI)
 - ability_id: 2a32e46f-5346-45d3-9475-52b857c05342
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        |SPAWN|
+      - var: default
+          - default:
+            status: 0
+            response: |
+              |SPAWN|
 
 # Start 54ndc47
 - ability_id: 10a9d979-e342-418a-a9b0-002c483e0fa6
   paws:
     - paw: xwing$redleader
-      status: 0
-      response: |
-        |SPAWN|
+      - var: default
+          - default:
+            status: 0
+            response: |
+              |SPAWN|
     - paw: millenniumfalcon$hansolo
-      status: 0
-      response: |
-        |SPAWN|
+      - var: default
+          - default:
+            status: 0
+            response: |
+              |SPAWN|
 
 # Start Agent (WinRM)
 - ability_id: 41bb2b7a-75af-49fd-bd15-6c827df25921
   paws:
     - paw: deathstar$darthvader
-      status: 0
-      response: |
-        |SPAWN|
+      - var: default
+          - default:
+            status: 0
+            response: |
+              |SPAWN|

--- a/mock.sql
+++ b/mock.sql
@@ -1,1 +1,1 @@
-CREATE TABLE if not exists sim_response (id integer primary key AUTOINCREMENT, ability_id text, paw text, status integer, response text, UNIQUE (ability_id, paw) ON CONFLICT IGNORE);
+CREATE TABLE if not exists sim_response (id integer primary key AUTOINCREMENT, ability_id text, paw text, status integer, var text, val text, response text, UNIQUE (ability_id, paw, val, var) ON CONFLICT IGNORE);


### PR DESCRIPTION
A solution to allow customized response per fact/value pair per ability within the mock plugin. 


Note: The code here works well and is very extensible, but I'm not 100% sold on the best way to store the nxn options per ability, so thoughts about ways to do this would be great. It's worth noting we're going to want to break  responses.yml into a series of files much like normal abilities at some point in the near future.