### PR TITLE
Alice in Mock

### DIFF
--- a/app/simulation_svc.py
+++ b/app/simulation_svc.py
@@ -68,7 +68,7 @@ class SimulationService(BaseService):
                       ppid=randint(1000, 10000), privilege=agent['privilege'], c2=agent['c2'], trusted=True,
                       exe_name=agent['exe_name'])
         await self.data_svc.store(agent)
-        agent.sleep_min = agent.sleep_max = 15
+        agent.sleep_min = agent.sleep_max = randint(55, 65)
         loop = asyncio.get_event_loop()
         loop.create_task(self.run(agent))
 

--- a/app/simulation_svc.py
+++ b/app/simulation_svc.py
@@ -68,7 +68,7 @@ class SimulationService(BaseService):
                       ppid=randint(1000, 10000), privilege=agent['privilege'], c2=agent['c2'], trusted=True,
                       exe_name=agent['exe_name'])
         await self.data_svc.store(agent)
-        agent.sleep_min = agent.sleep_max = randint(55, 65)
+        agent.sleep_min = agent.sleep_max = 15
         loop = asyncio.get_event_loop()
         loop.create_task(self.run(agent))
 
@@ -93,11 +93,12 @@ class SimulationService(BaseService):
 
     async def _spawn_new_sim(self, link):
         filtered = [a for a in self.agents if not a['enabled']]
-        run_on = (await self.data_svc.locate('agents', match=dict(paw=link['paw'])))[0]
-        command_actual = self.decode_bytes(link['command'])
+        run_on = (await self.data_svc.locate('agents', match=dict(paw=link.paw)))[0]
+        command_actual = self.decode_bytes(link.command)
         for agent in filtered:
-            box, user = agent['paw'].split('$')
-            if user in command_actual and box in command_actual and run_on['platform'] == agent['os']:
+            box = agent['host']
+            user = agent['username']
+            if user in command_actual and box in command_actual and run_on.platform == agent['platform']:
                 await self.start_agent(agent)
                 return True
         return False

--- a/conf/agents.yml
+++ b/conf/agents.yml
@@ -92,3 +92,45 @@
   exe_name: sandcat.sh
   executors:
     - sh
+
+- paw: 9231
+  username: Administrator
+  host: host1
+  group: alice
+  platform: windows
+  location: C:\Users\Public
+  enabled: True
+  privilege: User
+  c2: HTTP
+  exe_name: sandcat.exe
+  executors:
+    - pwsh
+    - psh
+
+- paw: 1145
+  username: Administrator
+  host: host2
+  group: alice
+  platform: windows
+  location: C:\Users\Public
+  enabled: False
+  privilege: User
+  c2: HTTP
+  exe_name: sandcat.exe
+  executors:
+    - pwsh
+    - psh
+
+- paw: 4251
+  username: Administrator
+  host: win-srhiq4j4rov
+  group: alice
+  platform: windows
+  location: C:\Users\Public
+  enabled: False
+  privilege: User
+  c2: HTTP
+  exe_name: sandcat.exe
+  executors:
+    - pwsh
+    - psh

--- a/conf/scenarios/alice.yml
+++ b/conf/scenarios/alice.yml
@@ -1,0 +1,17 @@
+---
+
+name: alice
+type: advanced
+responses:
+  # Powerkatz (staged)
+  - ability_id: 7049e3ec-b822-4fdf-a4ac-18190f9b66d1
+  # Find Domain
+  - ability_id: 14a21534-350f-4d83-9dd7-3c56b93a0c17
+  # Discover Local Hosts
+  - ability_id: 13379ae1-d20e-4162-91f8-320d78a35e7f
+  # Mount Share
+  - ability_id: aa6ec4dd-db09-4925-b9b9-43adeb154686
+  # Copy 54ndc47 (SMB)
+  - ability_id: 65048ec1-f7ca-49d3-9410-10813e472b30
+  # Start 54ndc47 (WMI)
+  - ability_id: ece5dde3-d370-4c20-b213-a1f424aa8d03

--- a/data/alice/13379ae1-d20e-4162-91f8-320d78a35e7f.yml
+++ b/data/alice/13379ae1-d20e-4162-91f8-320d78a35e7f.yml
@@ -1,0 +1,119 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          pwdlastset                    : 12/11/2019 10:27:45 AM
+          logoncount                    : 895
+          serverreferencebl             : CN=WIN-SRHIQ4J4ROV,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=f
+                                          lare,DC=local
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          lastlogontimestamp            : 12/11/2019 10:28:09 AM
+          name                          : WIN-SRHIQ4J4ROV
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1001
+          samaccountname                : WIN-SRHIQ4J4ROV$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          whenchanged                   : 12/11/2019 6:28:09 PM
+          accountexpires                : NEVER
+          countrycode                   : 0
+          operatingsystem               : Windows Server 2012 R2 Standard Evaluation
+          instancetype                  : 4
+          msdfsr-computerreferencebl    : CN=WIN-SRHIQ4J4ROV,CN=Topology,CN=Domain System
+                                          Volume,CN=DFSR-GlobalSettings,CN=System,DC=mock,DC=local
+          objectguid                    : ccfbe669-fa29-42f9-8eb4-532e372f7bec
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : {7/19/2017 9:52:29 PM, 1/1/1601 12:00:01 AM}
+          serviceprincipalname          : {Dfsr-12F9A27C-BF97-4787-9364-D31B6C55EB04/WIN-SRHIQ4J4ROV.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/ForestDnsZones.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/DomainDnsZones.mock.local,
+                                          DNS/WIN-SRHIQ4J4ROV.mock.local...}
+          usncreated                    : 12293
+          lastlogon                     : 12/11/2019 10:28:13 AM
+          badpwdcount                   : 0
+          cn                            : WIN-SRHIQ4J4ROV
+          useraccountcontrol            : SERVER_TRUST_ACCOUNT, TRUSTED_FOR_DELEGATION
+          whencreated                   : 7/19/2017 9:52:29 PM
+          primarygroupid                : 516
+          iscriticalsystemobject        : True
+          msds-supportedencryptiontypes : 28
+          usnchanged                    : 1372500
+          ridsetreferences              : CN=RID Set,CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          dnshostname                   : WIN-SRHIQ4J4ROV.mock.local
+
+          logoncount                    : 1032
+          badpasswordtime               : 11/8/2019 9:53:14 AM
+          distinguishedname             : CN=NET1,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 60
+          lastlogontimestamp            : 10/30/2019 10:15:52 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1104
+          samaccountname                : NET1$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : NET1
+          accountexpires                : NEVER
+          whenchanged                   : 10/30/2019 5:15:53 PM
+          instancetype                  : 4
+          usncreated                    : 12754
+          objectguid                    : ad860191-1093-4ca1-ab95-40b015e37038
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host1, WSMAN/host1.mock.local, RestrictedKrbHost/NET1, HOST/NET1...}
+          lastlogon                     : 11/8/2019 9:49:06 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1229112
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:26:19 PM
+          primarygroupid                : 515
+          pwdlastset                    : 10/30/2019 10:15:52 AM
+          msds-supportedencryptiontypes : 28
+          name                          : NET1
+          dnshostname                   : host1.mock.local
+
+          logoncount                    : 824
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=host2,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 0
+          lastlogontimestamp            : 12/11/2019 10:28:47 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1105
+          samaccountname                : NET2$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : host2
+          accountexpires                : NEVER
+          whenchanged                   : 12/11/2019 6:28:47 PM
+          instancetype                  : 4
+          usncreated                    : 12798
+          objectguid                    : b050b45c-4b1d-43bc-92b4-8959d1366c01
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host2, WSMAN/host2.mock.local, RestrictedKrbHost/host2, HOST/host2...}
+          lastlogon                     : 12/11/2019 10:28:56 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1372506
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:48:44 PM
+          primarygroupid                : 515
+          pwdlastset                    : 12/11/2019 10:28:47 AM
+          msds-supportedencryptiontypes : 28
+          name                          : host2
+          dnshostname                   : host2.mock.local

--- a/data/alice/13379ae1-d20e-4162-91f8-320d78a35e7f.yml
+++ b/data/alice/13379ae1-d20e-4162-91f8-320d78a35e7f.yml
@@ -117,3 +117,239 @@ paws:
           msds-supportedencryptiontypes : 28
           name                          : host2
           dnshostname                   : host2.mock.local
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          pwdlastset                    : 12/11/2019 10:27:45 AM
+          logoncount                    : 895
+          serverreferencebl             : CN=WIN-SRHIQ4J4ROV,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=f
+                                          lare,DC=local
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          lastlogontimestamp            : 12/11/2019 10:28:09 AM
+          name                          : WIN-SRHIQ4J4ROV
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1001
+          samaccountname                : WIN-SRHIQ4J4ROV$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          whenchanged                   : 12/11/2019 6:28:09 PM
+          accountexpires                : NEVER
+          countrycode                   : 0
+          operatingsystem               : Windows Server 2012 R2 Standard Evaluation
+          instancetype                  : 4
+          msdfsr-computerreferencebl    : CN=WIN-SRHIQ4J4ROV,CN=Topology,CN=Domain System
+                                          Volume,CN=DFSR-GlobalSettings,CN=System,DC=mock,DC=local
+          objectguid                    : ccfbe669-fa29-42f9-8eb4-532e372f7bec
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : {7/19/2017 9:52:29 PM, 1/1/1601 12:00:01 AM}
+          serviceprincipalname          : {Dfsr-12F9A27C-BF97-4787-9364-D31B6C55EB04/WIN-SRHIQ4J4ROV.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/ForestDnsZones.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/DomainDnsZones.mock.local,
+                                          DNS/WIN-SRHIQ4J4ROV.mock.local...}
+          usncreated                    : 12293
+          lastlogon                     : 12/11/2019 10:28:13 AM
+          badpwdcount                   : 0
+          cn                            : WIN-SRHIQ4J4ROV
+          useraccountcontrol            : SERVER_TRUST_ACCOUNT, TRUSTED_FOR_DELEGATION
+          whencreated                   : 7/19/2017 9:52:29 PM
+          primarygroupid                : 516
+          iscriticalsystemobject        : True
+          msds-supportedencryptiontypes : 28
+          usnchanged                    : 1372500
+          ridsetreferences              : CN=RID Set,CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          dnshostname                   : WIN-SRHIQ4J4ROV.mock.local
+
+          logoncount                    : 1032
+          badpasswordtime               : 11/8/2019 9:53:14 AM
+          distinguishedname             : CN=NET1,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 60
+          lastlogontimestamp            : 10/30/2019 10:15:52 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1104
+          samaccountname                : NET1$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : NET1
+          accountexpires                : NEVER
+          whenchanged                   : 10/30/2019 5:15:53 PM
+          instancetype                  : 4
+          usncreated                    : 12754
+          objectguid                    : ad860191-1093-4ca1-ab95-40b015e37038
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host1, WSMAN/host1.mock.local, RestrictedKrbHost/NET1, HOST/NET1...}
+          lastlogon                     : 11/8/2019 9:49:06 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1229112
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:26:19 PM
+          primarygroupid                : 515
+          pwdlastset                    : 10/30/2019 10:15:52 AM
+          msds-supportedencryptiontypes : 28
+          name                          : NET1
+          dnshostname                   : host1.mock.local
+
+          logoncount                    : 824
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=host2,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 0
+          lastlogontimestamp            : 12/11/2019 10:28:47 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1105
+          samaccountname                : NET2$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : host2
+          accountexpires                : NEVER
+          whenchanged                   : 12/11/2019 6:28:47 PM
+          instancetype                  : 4
+          usncreated                    : 12798
+          objectguid                    : b050b45c-4b1d-43bc-92b4-8959d1366c01
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host2, WSMAN/host2.mock.local, RestrictedKrbHost/host2, HOST/host2...}
+          lastlogon                     : 12/11/2019 10:28:56 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1372506
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:48:44 PM
+          primarygroupid                : 515
+          pwdlastset                    : 12/11/2019 10:28:47 AM
+          msds-supportedencryptiontypes : 28
+          name                          : host2
+          dnshostname                   : host2.mock.local
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          pwdlastset                    : 12/11/2019 10:27:45 AM
+          logoncount                    : 895
+          serverreferencebl             : CN=WIN-SRHIQ4J4ROV,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=f
+                                          lare,DC=local
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          lastlogontimestamp            : 12/11/2019 10:28:09 AM
+          name                          : WIN-SRHIQ4J4ROV
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1001
+          samaccountname                : WIN-SRHIQ4J4ROV$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          whenchanged                   : 12/11/2019 6:28:09 PM
+          accountexpires                : NEVER
+          countrycode                   : 0
+          operatingsystem               : Windows Server 2012 R2 Standard Evaluation
+          instancetype                  : 4
+          msdfsr-computerreferencebl    : CN=WIN-SRHIQ4J4ROV,CN=Topology,CN=Domain System
+                                          Volume,CN=DFSR-GlobalSettings,CN=System,DC=mock,DC=local
+          objectguid                    : ccfbe669-fa29-42f9-8eb4-532e372f7bec
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : {7/19/2017 9:52:29 PM, 1/1/1601 12:00:01 AM}
+          serviceprincipalname          : {Dfsr-12F9A27C-BF97-4787-9364-D31B6C55EB04/WIN-SRHIQ4J4ROV.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/ForestDnsZones.mock.local,
+                                          ldap/WIN-SRHIQ4J4ROV.mock.local/DomainDnsZones.mock.local,
+                                          DNS/WIN-SRHIQ4J4ROV.mock.local...}
+          usncreated                    : 12293
+          lastlogon                     : 12/11/2019 10:28:13 AM
+          badpwdcount                   : 0
+          cn                            : WIN-SRHIQ4J4ROV
+          useraccountcontrol            : SERVER_TRUST_ACCOUNT, TRUSTED_FOR_DELEGATION
+          whencreated                   : 7/19/2017 9:52:29 PM
+          primarygroupid                : 516
+          iscriticalsystemobject        : True
+          msds-supportedencryptiontypes : 28
+          usnchanged                    : 1372500
+          ridsetreferences              : CN=RID Set,CN=WIN-SRHIQ4J4ROV,OU=Domain Controllers,DC=mock,DC=local
+          dnshostname                   : WIN-SRHIQ4J4ROV.mock.local
+
+          logoncount                    : 1032
+          badpasswordtime               : 11/8/2019 9:53:14 AM
+          distinguishedname             : CN=NET1,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 60
+          lastlogontimestamp            : 10/30/2019 10:15:52 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1104
+          samaccountname                : NET1$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : NET1
+          accountexpires                : NEVER
+          whenchanged                   : 10/30/2019 5:15:53 PM
+          instancetype                  : 4
+          usncreated                    : 12754
+          objectguid                    : ad860191-1093-4ca1-ab95-40b015e37038
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host1, WSMAN/host1.mock.local, RestrictedKrbHost/NET1, HOST/NET1...}
+          lastlogon                     : 11/8/2019 9:49:06 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1229112
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:26:19 PM
+          primarygroupid                : 515
+          pwdlastset                    : 10/30/2019 10:15:52 AM
+          msds-supportedencryptiontypes : 28
+          name                          : NET1
+          dnshostname                   : host1.mock.local
+
+          logoncount                    : 824
+          badpasswordtime               : 12/31/1600 4:00:00 PM
+          distinguishedname             : CN=host2,CN=Computers,DC=mock,DC=local
+          objectclass                   : {top, person, organizationalPerson, user...}
+          badpwdcount                   : 0
+          lastlogontimestamp            : 12/11/2019 10:28:47 AM
+          objectsid                     : S-1-5-21-5376977-2392478274-3887395548-1105
+          samaccountname                : NET2$
+          localpolicyflags              : 0
+          codepage                      : 0
+          samaccounttype                : MACHINE_ACCOUNT
+          countrycode                   : 0
+          cn                            : host2
+          accountexpires                : NEVER
+          whenchanged                   : 12/11/2019 6:28:47 PM
+          instancetype                  : 4
+          usncreated                    : 12798
+          objectguid                    : b050b45c-4b1d-43bc-92b4-8959d1366c01
+          operatingsystem               : Windows 8.1 Enterprise Evaluation
+          operatingsystemversion        : 6.3 (9600)
+          lastlogoff                    : 12/31/1600 4:00:00 PM
+          objectcategory                : CN=Computer,CN=Schema,CN=Configuration,DC=mock,DC=local
+          dscorepropagationdata         : 1/1/1601 12:00:00 AM
+          serviceprincipalname          : {WSMAN/host2, WSMAN/host2.mock.local, RestrictedKrbHost/host2, HOST/host2...}
+          lastlogon                     : 12/11/2019 10:28:56 AM
+          iscriticalsystemobject        : False
+          usnchanged                    : 1372506
+          useraccountcontrol            : WORKSTATION_TRUST_ACCOUNT
+          whencreated                   : 7/19/2017 10:48:44 PM
+          primarygroupid                : 515
+          pwdlastset                    : 12/11/2019 10:28:47 AM
+          msds-supportedencryptiontypes : 28
+          name                          : host2
+          dnshostname                   : host2.mock.local

--- a/data/alice/14a21534-350f-4d83-9dd7-3c56b93a0c17.yml
+++ b/data/alice/14a21534-350f-4d83-9dd7-3c56b93a0c17.yml
@@ -1,0 +1,20 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Ethernet:
+          Node IpAddress: [192.168.56.102] Scope Id: []
+          
+                          NetBIOS Local Name Table
+          
+                 Name               Type         Status
+              ---------------------------------------------
+              HOST1          <00>  UNIQUE      Registered
+              MOCK           <00>  GROUP       Registered
+              HOST1          <20>  UNIQUE      Registered
+              MOCK           <1E>  GROUP       Registered
+              MOCK           <1D>  UNIQUE      Registered
+              __MSBROWSE__   <01>  GROUP       Registered

--- a/data/alice/14a21534-350f-4d83-9dd7-3c56b93a0c17.yml
+++ b/data/alice/14a21534-350f-4d83-9dd7-3c56b93a0c17.yml
@@ -18,3 +18,41 @@ paws:
               MOCK           <1E>  GROUP       Registered
               MOCK           <1D>  UNIQUE      Registered
               __MSBROWSE__   <01>  GROUP       Registered
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Ethernet:
+          Node IpAddress: [192.168.56.101] Scope Id: []
+
+                          NetBIOS Local Name Table
+
+                 Name               Type         Status
+              ---------------------------------------------
+              HOST2          <00>  UNIQUE      Registered
+              MOCK           <00>  GROUP       Registered
+              HOST2          <20>  UNIQUE      Registered
+              MOCK           <1E>  GROUP       Registered
+              MOCK           <1D>  UNIQUE      Registered
+              __MSBROWSE__   <01>  GROUP       Registered
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Ethernet:
+          Node IpAddress: [192.168.56.123] Scope Id: []
+
+                          NetBIOS Local Name Table
+
+                 Name               Type         Status
+              ---------------------------------------------
+              WIN-SRHIQ4J4ROV<00>  UNIQUE      Registered
+              MOCK           <00>  GROUP       Registered
+              WIN-SRHIQ4J4ROV<20>  UNIQUE      Registered
+              MOCK           <1E>  GROUP       Registered
+              MOCK           <1D>  UNIQUE      Registered
+              __MSBROWSE__   <01>  GROUP       Registered

--- a/data/alice/65048ec1-f7ca-49d3-9410-10813e472b30.yml
+++ b/data/alice/65048ec1-f7ca-49d3-9410-10813e472b30.yml
@@ -5,3 +5,15 @@ paws:
         value: default
         status: 0
         response: |
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |

--- a/data/alice/65048ec1-f7ca-49d3-9410-10813e472b30.yml
+++ b/data/alice/65048ec1-f7ca-49d3-9410-10813e472b30.yml
@@ -1,0 +1,7 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |

--- a/data/alice/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
+++ b/data/alice/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
@@ -33,3 +33,71 @@ paws:
                * Password : (null)
               ssp :	KO
               credman :
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Authentication Id : 0 ; 138572 (00000000:00021d4c)
+          Session           : Interactive from 1
+          User Name         : Administrator
+          Domain            : MOCK
+          Logon Server      : WIN-SRHIQ4J4ROV
+          Logon Time        : 12/11/2019 10:32:53 AM
+          SID               : S-1-5-21-5376977-2392478274-3887395548-500
+              msv :
+               [00010000] CredentialKeys
+               * NTLM     : 832c0fd93cb314ac7a47794622cbd1ff
+               * SHA1     : e573557a8fd29230116c00ebed42a02344b6b83d
+               [00000003] Primary
+               * Username : Administrator
+               * Domain   : MOCK
+               * NTLM     : 656b53c60bec1ef127fce1719f52b26c
+               * SHA1     : 8426f86601590be88c33eb116b23a8fbe31c67d2
+              tspkg :
+              wdigest :
+               * Username : Administrator
+               * Domain   : MOCK
+               * Password : Bonkers!@#123
+              livessp :
+              kerberos :
+               * Username : Administrator
+               * Domain   : MOCK.LOCAL
+               * Password : (null)
+              ssp :	KO
+              credman :
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Authentication Id : 0 ; 138572 (00000000:00021d4c)
+          Session           : Interactive from 1
+          User Name         : Administrator
+          Domain            : MOCK
+          Logon Server      : WIN-SRHIQ4J4ROV
+          Logon Time        : 12/11/2019 10:32:53 AM
+          SID               : S-1-5-21-5376977-2392478274-3887395548-500
+              msv :
+               [00010000] CredentialKeys
+               * NTLM     : 832c0fd93cb314ac7a47794622cbd1ff
+               * SHA1     : e573557a8fd29230116c00ebed42a02344b6b83d
+               [00000003] Primary
+               * Username : Administrator
+               * Domain   : MOCK
+               * NTLM     : 656b53c60bec1ef127fce1719f52b26c
+               * SHA1     : 8426f86601590be88c33eb116b23a8fbe31c67d2
+              tspkg :
+              wdigest :
+               * Username : Administrator
+               * Domain   : MOCK
+               * Password : Bonkers!@#123
+              livessp :
+              kerberos :
+               * Username : Administrator
+               * Domain   : MOCK.LOCAL
+               * Password : (null)
+              ssp :	KO
+              credman :

--- a/data/alice/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
+++ b/data/alice/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
@@ -1,0 +1,35 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          Authentication Id : 0 ; 138572 (00000000:00021d4c)
+          Session           : Interactive from 1
+          User Name         : Administrator
+          Domain            : MOCK
+          Logon Server      : WIN-SRHIQ4J4ROV
+          Logon Time        : 12/11/2019 10:32:53 AM
+          SID               : S-1-5-21-5376977-2392478274-3887395548-500
+              msv :
+               [00010000] CredentialKeys
+               * NTLM     : 832c0fd93cb314ac7a47794622cbd1ff
+               * SHA1     : e573557a8fd29230116c00ebed42a02344b6b83d
+               [00000003] Primary
+               * Username : Administrator
+               * Domain   : MOCK
+               * NTLM     : 656b53c60bec1ef127fce1719f52b26c
+               * SHA1     : 8426f86601590be88c33eb116b23a8fbe31c67d2
+              tspkg :
+              wdigest :
+               * Username : Administrator
+               * Domain   : MOCK
+               * Password : Bonkers!@#123
+              livessp :
+              kerberos :
+               * Username : Administrator
+               * Domain   : MOCK.LOCAL
+               * Password : (null)
+              ssp :	KO
+              credman :

--- a/data/alice/aa6ec4dd-db09-4925-b9b9-43adeb154686.yml
+++ b/data/alice/aa6ec4dd-db09-4925-b9b9-43adeb154686.yml
@@ -6,3 +6,17 @@ paws:
         status: 0
         response: |
          The command completed successfully.
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+         The command completed successfully.
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+         The command completed successfully.

--- a/data/alice/aa6ec4dd-db09-4925-b9b9-43adeb154686.yml
+++ b/data/alice/aa6ec4dd-db09-4925-b9b9-43adeb154686.yml
@@ -1,0 +1,8 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+         The command completed successfully.

--- a/data/alice/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
+++ b/data/alice/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
@@ -1,0 +1,8 @@
+paws:
+  - paw: 9231
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          |SPAWN|

--- a/data/alice/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
+++ b/data/alice/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
@@ -6,3 +6,17 @@ paws:
         status: 0
         response: |
           |SPAWN|
+  - paw: 1145
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          |SPAWN|
+  - paw: 4251
+    variables:
+      - trait: default
+        value: default
+        status: 0
+        response: |
+          |SPAWN|


### PR DESCRIPTION
Adds the underlying data that allows Alice to be run in Mock for testing purposes. Requires a small tweak to the gdomain parser (https://github.com/mitre/stockpile/pull/282/) in order to fully spread through the network, but successfully moves from one host to another without that patch. 