### PR TITLE
Replace ACRN vmlist output

### DIFF
--- a/data/hypervisor/0093c0e0-68b6-4cab-b0d4-2b40b3c78f71.yml
+++ b/data/hypervisor/0093c0e0-68b6-4cab-b0d4-2b40b3c78f71.yml
@@ -5,7 +5,5 @@ paws:
         value: default
         status: 0
         response: |
-           VM NAME                    VM ID       VM STATE
-           =======                    =====       ========
-           ACRN_VM                      0         Started
-           Mission_Critical_VM          1         Started
+          hard_rtvm		started
+          vm1		stopped


### PR DESCRIPTION
Old mock data is modeled after the debug ACRN shell which is only accessible over UART. The new data comes from the acrnctl utility which is can be accessed via console commands.