### PR TITLE
auth patch fix

### DIFF
--- a/app/simulation_api.py
+++ b/app/simulation_api.py
@@ -8,6 +8,8 @@ class SimulationApi:
 
     def __init__(self, services):
         self.services = services
+        # need the next line to make authentication checks work
+        self.auth_svc = services['auth_svc']
 
     @template('mock.html')
     @check_authorization


### PR DESCRIPTION
Quick patch to fix mis-reference of auth service (caused indirectly by https://github.com/mitre/mock/pull/40/files)

(I suspect that this issue exists/would exist in other plugins with
their own pages that require auth, but it appears that mock may be the
only one, and I don't think fixing this for a single instance is worth
tinkering with core code at the moment)