### PR TITLE
resolve ability has no parser error

### DIFF
--- a/app/simulation_svc.py
+++ b/app/simulation_svc.py
@@ -70,11 +70,7 @@ class SimulationService(BaseService):
         words = []
         for x in range(randint(1, 100)):
             words.append(self.generate_name(size=randint(2, 10)))
-        try:
-            parser = ability.parser
-        except AttributeError:  # the ability has no parser
-            parser = []
-        await ResultGenerator(parser).generate(words)
+        await ResultGenerator(getattr(ability, 'parser', [])).generate(words)
         return self.encode_string(' '.join(words)), status_code
 
     async def _spawn_new_sim(self, link):

--- a/app/simulation_svc.py
+++ b/app/simulation_svc.py
@@ -70,7 +70,11 @@ class SimulationService(BaseService):
         words = []
         for x in range(randint(1, 100)):
             words.append(self.generate_name(size=randint(2, 10)))
-        await ResultGenerator(ability.parsers).generate(words)
+        try:
+            parser = ability.parser
+        except AttributeError:  # the ability has no parser
+            parser = []
+        await ResultGenerator(parser).generate(words)
         return self.encode_string(' '.join(words)), status_code
 
     async def _spawn_new_sim(self, link):


### PR DESCRIPTION
## Description

Altering the `_getattr__` method of CALDERA core's `c_ability.py` appears to break link generation from the planning service.  An alternative is to pass a default (iterable) value using Python's `getattr()`, such that if CALDERA raises an `AttributeError`, the result generator does not throw an error.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by enabling the `mock` plugin in `conf/default.yml` and then running the `Collection` Adversary using the simulated agents.  Also tested with a real (locally deployed) agent alongside the above simulated agents.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
